### PR TITLE
Intel official release 0.0.768

### DIFF
--- a/idpf.spec
+++ b/idpf.spec
@@ -1,6 +1,6 @@
 Name: idpf
 Summary: Infrastructure Data Path Function Linux Driver
-Version: 0.0.766
+Version: 0.0.768
 Release: %{?dist}
 Source: %{name}-%{version}.tar.gz
 Vendor: Intel Corporation

--- a/idpf/pci.updates
+++ b/idpf/pci.updates
@@ -9,7 +9,7 @@
 #             (numerical order).
 #
 8086  Intel Corporation
-        1452  Smart Network Adapter ES2000
-        145c  Smart Network Adapter ES2000 Virtual Function
+        1452  Infrastructure Data Path Function
+        145c  Infrastructure Data Path Function
         0dd5  SIOV Virtual Function
 

--- a/idpf/src/idpf.h
+++ b/idpf/src/idpf.h
@@ -52,7 +52,7 @@ struct idpf_rss_data;
 #endif /* CONFIG_IOMMU_BYPASS */
 
 #define IDPF_DRV_NAME "idpf"
-#define IDPF_DRV_VER "0.0.766"
+#define IDPF_DRV_VER "0.0.768"
 
 #define IDPF_M(m, s)	((m) << (s))
 

--- a/idpf/src/idpf_ethtool.c
+++ b/idpf/src/idpf_ethtool.c
@@ -1611,8 +1611,13 @@ static void idpf_get_drvinfo(struct net_device *netdev,
  *
  * Set the Tx/Rx timestamp filters
  */
+#ifdef HAVE_ETHTOOL_KERNEL_TS_INFO
+static void idpf_set_timestamp_filters(struct idpf_vport *vport,
+				       struct kernel_ethtool_ts_info *info)
+#else
 static void idpf_set_timestamp_filters(struct idpf_vport *vport,
 				       struct ethtool_ts_info *info)
+#endif /* HAVE_ETHTOOL_KERNEL_TS_INFO */
 {
 	if (vport->adapter->ptp.tx_tstamp_access == IDPF_PTP_NONE ||
 	    !vport->tx_tstamp_caps)
@@ -1634,8 +1639,13 @@ static void idpf_set_timestamp_filters(struct idpf_vport *vport,
  * @netdev: network interface device structure
  * @info: ethtool timestamping info structure
  */
+#ifdef HAVE_ETHTOOL_KERNEL_TS_INFO
+static int idpf_get_ts_info(struct net_device *netdev,
+			    struct kernel_ethtool_ts_info *info)
+#else
 static int idpf_get_ts_info(struct net_device *netdev,
 			    struct ethtool_ts_info *info)
+#endif /* HAVE_ETHTOOL_KERNEL_TS_INFO */
 {
 	struct idpf_adapter *adapter = idpf_netdev_to_adapter(netdev);
 	struct idpf_vport *vport;

--- a/idpf/src/idpf_lib.c
+++ b/idpf/src/idpf_lib.c
@@ -1799,7 +1799,7 @@ void idpf_tstamp_task(struct work_struct *work)
 
 	vport = container_of(work, struct idpf_vport, tstamp_task);
 
-	idpf_ptp_get_tx_tstamp(vport);
+	idpf_ptp_get_tx_tstamp_mb(vport);
 }
 
 /**

--- a/idpf/src/idpf_ptp.h
+++ b/idpf/src/idpf_ptp.h
@@ -10,6 +10,8 @@
 #include <linux/ptp_clock_kernel.h>
 #include <linux/ptp_classify.h>
 
+#define IDPF_PTP_VALID_BIT BIT(0)
+
 enum idpf_ptp_access {
 	IDPF_PTP_NONE = 0,
 	IDPF_PTP_DIRECT,
@@ -110,8 +112,8 @@ struct idpf_ptp_vport_tx_tstamp_caps {
 	u32 vport_id;
 	u16 num_entries;
 	u8 tstamp_ns_lo_bit;
-	struct mutex lock_in_use; /* lock to used latches list */
-	struct mutex lock_free; /* lock to free latches list */
+	spinlock_t lock_in_use; /* lock to used latches list */
+	spinlock_t lock_free; /* lock to free latches list */
 	struct list_head latches_free;
 	struct list_head latches_in_use;
 	struct idpf_ptp_tx_tstamp_status *tx_tstamp_status;
@@ -175,11 +177,12 @@ int idpf_ptp_get_cross_time(struct idpf_adapter *adapter,
 int idpf_ptp_set_dev_clk_time(struct idpf_adapter *adapter, u64 time);
 int idpf_ptp_adj_dev_clk_fine(struct idpf_adapter *adapter, u64 incval);
 int idpf_ptp_adj_dev_clk_time(struct idpf_adapter *adapter, s64 delta);
+int idpf_ptp_get_tx_tstamp_mb(struct idpf_vport *vport);
 int idpf_ptp_get_tx_tstamp(struct idpf_vport *vport);
 int idpf_ptp_get_ts_config(struct idpf_vport *vport, struct ifreq *ifr);
 int idpf_ptp_set_ts_config(struct idpf_vport *vport, struct ifreq *ifr);
 s8 idpf_ptp_request_ts(struct idpf_vport *vport, struct sk_buff *skb);
-u64 idpf_ptp_extend_ts(struct idpf_adapter *adapter, u32 in_tstamp);
+u64 idpf_ptp_extend_ts(struct idpf_adapter *adapter, u64 in_tstamp);
 u64 idpf_ptp_tstamp_extend_32b_to_64b(u64 cached_phc_time, u32 in_timestamp);
 #else /* IS_ENABLED(CONFIG_PTP_1588_CLOCK) */
 static inline int idpf_ptp_get_caps(struct idpf_adapter *adapter)
@@ -232,6 +235,11 @@ static inline int idpf_ptp_adj_dev_clk_time(struct idpf_adapter *adapter,
 	return -EOPNOTSUPP;
 }
 
+static inline int idpf_ptp_get_tx_tstamp_mb(struct idpf_vport *vport)
+{
+	return -EOPNOTSUPP;
+}
+
 static inline int idpf_ptp_get_tx_tstamp(struct idpf_vport *vport)
 {
 	return -EOPNOTSUPP;
@@ -256,7 +264,7 @@ static inline s8 idpf_ptp_request_ts(struct idpf_vport *vport,
 }
 
 static inline u64 idpf_ptp_extend_ts(struct idpf_adapter *adapter,
-				     u32 in_tstamp)
+				     u64 in_tstamp)
 {
 	return 0;
 }
@@ -266,5 +274,6 @@ static inline u64 idpf_ptp_tstamp_extend_32b_to_64b(u64 cached_phc_time,
 {
 	return 0;
 }
+
 #endif /* IS_ENABLED(CONFIG_PTP_1588_CLOCK) */
 #endif /* _IDPF_PTP_H_ */

--- a/idpf/src/idpf_txrx.c
+++ b/idpf/src/idpf_txrx.c
@@ -168,6 +168,9 @@ static void idpf_tx_buf_rel_all(struct idpf_queue *txq)
  */
 static void idpf_tx_desc_rel(struct idpf_queue *txq, bool bufq)
 {
+	if (!txq)
+		return;
+
 	if (bufq) {
 		idpf_tx_buf_rel_all(txq);
 #ifdef HAVE_XDP_SUPPORT
@@ -206,7 +209,7 @@ static void idpf_tx_desc_rel_all(struct idpf_q_grp *q_grp)
 	for (i = 0; i < q_grp->num_txq; i++)
 		idpf_tx_desc_rel(q_grp->txqs[i], true);
 
-	if (!idpf_is_queue_model_split(q_grp->txq_model))
+	if (!q_grp->complqs)
 		return;
 
 	for (i = 0; i < q_grp->num_complq; i++)
@@ -452,7 +455,7 @@ static void idpf_rx_buf_rel_all(struct idpf_queue *q)
 #endif /* HAVE_NETDEV_BPF_XSK_POOL */
 			idpf_rx_buf_rel(q, &q->rx.bufs[i]);
 
-	if (q->rx_hsplit_en)
+	if (q->rx.hdr_buf_va)
 		idpf_rx_hdr_buf_rel(q);
 
 	kfree(q->rx.bufs);
@@ -910,15 +913,13 @@ static void idpf_tx_queue_rel_all(struct idpf_q_grp *q_grp)
 {
 	int i;
 
+	/* If we failed to allcoate txqs, no need to release complqs since they
+	 * won't have been allocated.
+	 */
+	if (!q_grp->txqs)
+		return;
+
 	idpf_tx_desc_rel_all(q_grp);
-
-	for (i = 0; i < q_grp->num_complq; i++) {
-		kfree(q_grp->complqs[i].tx.txqs);
-		q_grp->complqs[i].tx.txqs = NULL;
-	}
-
-	kfree(q_grp->complqs);
-	q_grp->complqs = NULL;
 
 	for (i = 0; i < q_grp->num_txq; i++) {
 		kfree(q_grp->txqs[i]);
@@ -927,6 +928,17 @@ static void idpf_tx_queue_rel_all(struct idpf_q_grp *q_grp)
 
 	kfree(q_grp->txqs);
 	q_grp->txqs = NULL;
+
+	if (!q_grp->complqs)
+		return;
+
+	for (i = 0; i < q_grp->num_complq; i++) {
+		kfree(q_grp->complqs[i].tx.txqs);
+		q_grp->complqs[i].tx.txqs = NULL;
+	}
+
+	kfree(q_grp->complqs);
+	q_grp->complqs = NULL;
 }
 
 /**
@@ -971,6 +983,9 @@ static void idpf_rxq_rel(struct idpf_q_grp *q_grp, struct idpf_queue *rxq,
  */
 static void idpf_bufq_rel(struct idpf_queue *bufq)
 {
+	if (!bufq)
+		return;
+
 	idpf_rx_buf_rel_all(bufq);
 
 	if (!bufq->desc_ring)
@@ -991,10 +1006,18 @@ static void idpf_rx_queue_rel_all(struct idpf_q_grp *q_grp)
 	if (!idpf_is_queue_model_split(q_grp->rxq_model))
 		goto rxq_rel;
 
+	if (!q_grp->bufqs)
+		goto rxq_rel;
+
 	for (i = 0; i < q_grp->num_bufq; i++) {
 		idpf_bufq_rel(&q_grp->bufqs[i]);
+
 		if (q_grp->type == IDPF_GRP_TYPE_P2P)
 			continue;
+
+		if (!q_grp->refillqs)
+			continue;
+
 		kfree(q_grp->refillqs[i].ring);
 	}
 
@@ -1007,7 +1030,13 @@ static void idpf_rx_queue_rel_all(struct idpf_q_grp *q_grp)
 	q_grp->refillqs = NULL;
 
 rxq_rel:
+	if (!q_grp->rxqs)
+		return;
+
 	for (i = 0; i < q_grp->num_rxq; i++) {
+		if (!q_grp->rxqs[i])
+			continue;
+
 		idpf_rxq_rel(q_grp, q_grp->rxqs[i], q_grp->bufq_per_rxq);
 #ifdef HAVE_XDP_BUFF_RXQ
 		if (xdp_rxq_info_is_reg(&q_grp->rxqs[i]->xdp_rxq))
@@ -1860,6 +1889,48 @@ static void idpf_tx_splitq_clean_hdr(struct idpf_queue *tx_q,
 }
 
 /**
+ * idpf_tx_read_tstamp - schedule a work to read Tx timestamp value
+ * @txq: queue to read the timestamp from
+ * @skb: socket buffer to provide Tx timestamp value
+ *
+ * Schedule a work to read Tx timestamp value generated once the packet is
+ * transmitted.
+ */
+static void idpf_tx_read_tstamp(struct idpf_queue *txq, struct sk_buff *skb)
+{
+	struct idpf_ptp_vport_tx_tstamp_caps *tx_tstamp_caps;
+	struct idpf_ptp_tx_tstamp_status *tx_tstamp_status;
+	enum idpf_ptp_access access;
+	int i;
+
+	if (!txq->vport->tx_tstamp_caps)
+		return;
+
+	access = txq->vport->adapter->ptp.tx_tstamp_access;
+	tx_tstamp_caps = txq->vport->tx_tstamp_caps;
+
+	for (i = 0; i < tx_tstamp_caps->num_entries; i++) {
+		tx_tstamp_status = &tx_tstamp_caps->tx_tstamp_status[i];
+		if (tx_tstamp_status->state == IDPF_PTP_FREE) {
+			tx_tstamp_status->skb = skb;
+			tx_tstamp_status->state = IDPF_PTP_REQUEST;
+
+			if (access == IDPF_PTP_MAILBOX) {
+				/* Fetch timestamp from completion descriptor through
+				 * virtchnl msg to report to stack.
+				 */
+				queue_work(system_unbound_wq,
+					   &txq->vport->tstamp_task);
+			} else if (access == IDPF_PTP_DIRECT) {
+				idpf_ptp_get_tx_tstamp(txq->vport);
+			}
+
+			break;
+		}
+	}
+}
+
+/**
  * idpf_tx_clean_stashed_bufs - clean bufs that were stored for
  * out of order completions
  * @txq: queue to clean
@@ -1872,11 +1943,8 @@ static void
 idpf_tx_clean_stashed_bufs(struct idpf_queue *txq, u16 compl_tag, u8 *desc_ts,
 			   struct idpf_cleaned_stats *cleaned, int budget)
 {
-	struct idpf_ptp_vport_tx_tstamp_caps *tx_tstamp_caps = txq->vport->tx_tstamp_caps;
-	struct idpf_ptp_tx_tstamp_status *tx_tstamp_status;
 	struct idpf_tx_stash *stash;
 	struct hlist_node *tmp_buf;
-	u16 i;
 
 	/* Buffer completion */
 	hash_for_each_possible_safe(txq->sched_buf_hash, stash, tmp_buf,
@@ -1891,21 +1959,7 @@ idpf_tx_clean_stashed_bufs(struct idpf_queue *txq, u16 compl_tag, u8 *desc_ts,
 			if (!(skb_shinfo(stash->buf.skb)->tx_flags & SKBTX_IN_PROGRESS))
 				goto skip_tx_tstamp;
 
-			for (i = 0; i < tx_tstamp_caps->num_entries; i++) {
-				tx_tstamp_status = &tx_tstamp_caps->tx_tstamp_status[i];
-				if (tx_tstamp_status->state == IDPF_PTP_FREE) {
-					tx_tstamp_status->skb = stash->buf.skb;
-					tx_tstamp_status->state = IDPF_PTP_REQUEST;
-
-					/* Fetch timestamp from completion
-					 * descriptor through virtchnl msg to
-					 * report to stack.
-					 */
-					queue_work(system_unbound_wq,
-						   &txq->vport->tstamp_task);
-					break;
-				}
-			}
+			idpf_tx_read_tstamp(txq, stash->buf.skb);
 skip_tx_tstamp:
 			idpf_tx_splitq_clean_hdr(txq, &stash->buf, cleaned,
 						 budget);
@@ -2187,12 +2241,9 @@ static bool idpf_tx_clean_buf_ring(struct idpf_queue *txq, u16 compl_tag,
 				   struct idpf_cleaned_stats *cleaned,
 				   u8 *desc_ts, int budget)
 {
-	struct idpf_ptp_vport_tx_tstamp_caps *tx_tstamp_caps = txq->vport->tx_tstamp_caps;
-	struct idpf_ptp_tx_tstamp_status *tx_tstamp_status;
 	u16 idx = compl_tag & txq->compl_tag_bufid_m;
 	u16 ntc, eop_idx, orig_idx = idx;
 	struct idpf_tx_buf *tx_buf;
-	u16 i;
 
 	tx_buf = &txq->tx.bufs[idx];
 
@@ -2204,20 +2255,7 @@ static bool idpf_tx_clean_buf_ring(struct idpf_queue *txq, u16 compl_tag,
 		if (!(skb_shinfo(tx_buf->skb)->tx_flags & SKBTX_IN_PROGRESS))
 			goto skip_tx_tstamp;
 
-		for (i = 0; i < tx_tstamp_caps->num_entries; i++) {
-			tx_tstamp_status = &tx_tstamp_caps->tx_tstamp_status[i];
-			if (tx_tstamp_status->state == IDPF_PTP_FREE) {
-				tx_tstamp_status->skb = tx_buf->skb;
-				tx_tstamp_status->state = IDPF_PTP_REQUEST;
-
-				/* Fetch timestamp from completion descriptor
-				 * through virtchnl msg to report to stack.
-				 */
-				queue_work(system_unbound_wq,
-					   &txq->vport->tstamp_task);
-				break;
-			}
-		}
+		idpf_tx_read_tstamp(txq, tx_buf->skb);
 skip_tx_tstamp:
 		eop_idx = tx_buf->eop_idx;
 		idpf_tx_splitq_clean_hdr(txq, tx_buf, cleaned, budget);
@@ -3507,7 +3545,7 @@ static bool idpf_tx_tstamp(struct idpf_queue *tx_q, u8 *index,
 		return false;
 
 	access = tx_q->vport->adapter->ptp.tx_tstamp_access;
-	if (access != IDPF_PTP_MAILBOX)
+	if (access == IDPF_PTP_NONE)
 		return false;
 
 	/* Grab an open timestamp slot */

--- a/idpf/src/idpf_txrx.h
+++ b/idpf/src/idpf_txrx.h
@@ -73,7 +73,7 @@
 /* Default vector sharing */
 #define IDPF_MBX_Q_VEC		1
 #define IDPF_MIN_Q_VEC		1
-#define IDPF_MIN_RDMA_VEC	4 /* Minimum vectors to be shared with RDMA */
+#define IDPF_MIN_RDMA_VEC	2 /* Minimum vectors to be shared with RDMA */
 
 #define IDPF_DFLT_TX_Q_DESC_COUNT		512
 #define IDPF_DFLT_TX_COMPLQ_DESC_COUNT		512

--- a/idpf/src/idpf_virtchnl.c
+++ b/idpf/src/idpf_virtchnl.c
@@ -1043,6 +1043,7 @@ static int idpf_ptp_get_vport_tstamps_caps(struct idpf_vport *vport)
 	enum idpf_ptp_access access_type;
 	int err = 0, i, reply_sz;
 	struct list_head *head;
+	unsigned long flags;
 	u16 num_latches;
 	u32 size;
 
@@ -1089,8 +1090,8 @@ static int idpf_ptp_get_vport_tstamps_caps(struct idpf_vport *vport)
 	INIT_LIST_HEAD(&tx_tstamp_caps->latches_in_use);
 	INIT_LIST_HEAD(&tx_tstamp_caps->latches_free);
 
-	mutex_init(&tx_tstamp_caps->lock_free);
-	mutex_init(&tx_tstamp_caps->lock_in_use);
+	spin_lock_init(&tx_tstamp_caps->lock_free);
+	spin_lock_init(&tx_tstamp_caps->lock_in_use);
 
 	tx_tstamp_caps->tstamp_ns_lo_bit = rcv_tx_tstamp_caps->tstamp_ns_lo_bit;
 
@@ -1118,9 +1119,9 @@ static int idpf_ptp_get_vport_tstamps_caps(struct idpf_vport *vport)
 
 		ptp_tx_tstamp->idx = rcv_tx_tstamp_caps->tstamp_latches[i].index;
 
-		mutex_lock(&tx_tstamp_caps->lock_free);
+		spin_lock_irqsave(&tx_tstamp_caps->lock_free, flags);
 		list_add(&ptp_tx_tstamp->list_member, &tx_tstamp_caps->latches_free);
-		mutex_unlock(&tx_tstamp_caps->lock_free);
+		spin_unlock_irqrestore(&tx_tstamp_caps->lock_free, flags);
 
 		tx_tstamp_caps->tx_tstamp_status[i].state = IDPF_PTP_FREE;
 	}
@@ -1128,13 +1129,13 @@ static int idpf_ptp_get_vport_tstamps_caps(struct idpf_vport *vport)
 	goto get_tstamp_caps_out;
 
 err_free_ptp_tx_stamp_list:
-	mutex_lock(&tx_tstamp_caps->lock_free);
+	spin_lock_irqsave(&tx_tstamp_caps->lock_free, flags);
 	head = &tx_tstamp_caps->latches_free;
 	list_for_each_entry_safe(ptp_tx_tstamp, tmp, head, list_member) {
 		list_del(&ptp_tx_tstamp->list_member);
 		kfree(ptp_tx_tstamp);
 	}
-	mutex_unlock(&tx_tstamp_caps->lock_free);
+	spin_unlock_irqrestore(&tx_tstamp_caps->lock_free, flags);
 err_free_tstamp_caps:
 	kfree(tx_tstamp_caps);
 get_tstamp_caps_out:
@@ -1317,9 +1318,9 @@ int idpf_ptp_adj_dev_clk_fine(struct idpf_adapter *adapter, u64 incval)
  *
  * Returns 0 on success, negative otherwise.
  */
-static int idpf_ptp_get_tx_tstamp_async_handler(struct idpf_adapter *adapter,
-						struct idpf_vc_xn *xn,
-						const struct idpf_ctlq_msg *ctlq_msg)
+static int idpf_ptp_get_tx_tstamp_mb_async_handler(struct idpf_adapter *adapter,
+						   struct idpf_vc_xn *xn,
+						   const struct idpf_ctlq_msg *ctlq_msg)
 {
 	struct virtchnl2_ptp_get_vport_tx_tstamp_latches *recv_tx_tstamp_latches_msg;
 	bool vport_found = false, tracker_found = false, idx_found = false;
@@ -1357,13 +1358,15 @@ static int idpf_ptp_get_tx_tstamp_async_handler(struct idpf_adapter *adapter,
 	num_latches = le16_to_cpu(recv_tx_tstamp_latches_msg->num_latches);
 
 	for (i = 0; i < num_latches; i++) {
+		unsigned long flags;
+
 		idx = recv_tx_tstamp_latches_msg->tstamp_latches[i].index;
 		valid = recv_tx_tstamp_latches_msg->tstamp_latches[i].valid;
 
 		if (!valid)
 			continue;
 
-		mutex_lock(&tx_tstamp_caps->lock_in_use);
+		spin_lock_irqsave(&tx_tstamp_caps->lock_in_use, flags);
 		list_for_each_entry(ptp_tx_tstamp, head, list_member) {
 			if (idx == ptp_tx_tstamp->idx) {
 				idx_found = true;
@@ -1371,7 +1374,7 @@ static int idpf_ptp_get_tx_tstamp_async_handler(struct idpf_adapter *adapter,
 				break;
 			}
 		}
-		mutex_unlock(&tx_tstamp_caps->lock_in_use);
+		spin_unlock_irqrestore(&tx_tstamp_caps->lock_in_use, flags);
 
 		if (!idx_found)
 			continue;
@@ -1379,7 +1382,7 @@ static int idpf_ptp_get_tx_tstamp_async_handler(struct idpf_adapter *adapter,
 		ptp_tx_tstamp->tstamp = le64_to_cpu(recv_tx_tstamp_latches_msg->tstamp_latches[i].tstamp);
 		ptp_tx_tstamp->tstamp >>= tstamp_ns_lo_bit;
 
-		tstamp = idpf_ptp_extend_ts(vport->adapter, (u32)ptp_tx_tstamp->tstamp);
+		tstamp = idpf_ptp_extend_ts(vport->adapter, ptp_tx_tstamp->tstamp);
 
 		for (id = 0; id < tx_tstamp_caps->num_entries; id++) {
 			if (ptp_tx_tstamp->skb == tx_tstamp_caps->tx_tstamp_status[id].skb &&
@@ -1399,10 +1402,10 @@ static int idpf_ptp_get_tx_tstamp_async_handler(struct idpf_adapter *adapter,
 
 		dev_kfree_skb_any(skb);
 
-		mutex_lock(&tx_tstamp_caps->lock_free);
+		spin_lock_irqsave(&tx_tstamp_caps->lock_free, flags);
 		list_add(&ptp_tx_tstamp->list_member,
 			 &tx_tstamp_caps->latches_free);
-		mutex_unlock(&tx_tstamp_caps->lock_free);
+		spin_unlock_irqrestore(&tx_tstamp_caps->lock_free, flags);
 	}
 
 	return 0;
@@ -1417,7 +1420,7 @@ static int idpf_ptp_get_tx_tstamp_async_handler(struct idpf_adapter *adapter,
  *
  * Returns 0 on success, negative otherwise.
  */
-int idpf_ptp_get_tx_tstamp(struct idpf_vport *vport)
+int idpf_ptp_get_tx_tstamp_mb(struct idpf_vport *vport)
 {
 	struct virtchnl2_ptp_get_vport_tx_tstamp_latches *send_tx_tstamp_latches_msg;
 	struct idpf_ptp_vport_tx_tstamp_caps *tx_tstamp_caps = vport->tx_tstamp_caps;
@@ -1425,6 +1428,7 @@ int idpf_ptp_get_tx_tstamp(struct idpf_vport *vport)
 	struct idpf_vc_xn_params xn_params = { };
 	struct idpf_ptp_tx_tstamp *ptp_tx_tstamp;
 	int reply_sz, msg_size, size, err = 0;
+	unsigned long flags;
 	u16 id = 0, i;
 
 	size = struct_size(send_tx_tstamp_latches_msg, tstamp_latches,
@@ -1434,7 +1438,7 @@ int idpf_ptp_get_tx_tstamp(struct idpf_vport *vport)
 	if (!send_tx_tstamp_latches_msg)
 		return -ENOMEM;
 
-	mutex_lock(&tx_tstamp_caps->lock_in_use);
+	spin_lock_irqsave(&tx_tstamp_caps->lock_in_use, flags);
 	list_for_each_entry(ptp_tx_tstamp, head, list_member) {
 		for (i = 0; i < tx_tstamp_caps->num_entries; i++) {
 			if (tx_tstamp_caps->tx_tstamp_status[i].skb == ptp_tx_tstamp->skb  &&
@@ -1446,7 +1450,7 @@ int idpf_ptp_get_tx_tstamp(struct idpf_vport *vport)
 			}
 		}
 	}
-	mutex_unlock(&tx_tstamp_caps->lock_in_use);
+	spin_unlock_irqrestore(&tx_tstamp_caps->lock_in_use, flags);
 
 	send_tx_tstamp_latches_msg->vport_id = cpu_to_le32(vport->vport_id);
 	send_tx_tstamp_latches_msg->num_latches = cpu_to_le16(id);
@@ -1461,7 +1465,7 @@ int idpf_ptp_get_tx_tstamp(struct idpf_vport *vport)
 	xn_params.send_buf.iov_len = msg_size;
 	xn_params.timeout_ms = IDPF_VC_XN_DEFAULT_TIMEOUT_MSEC;
 	xn_params.async = true;
-	xn_params.async_handler = idpf_ptp_get_tx_tstamp_async_handler;
+	xn_params.async_handler = idpf_ptp_get_tx_tstamp_mb_async_handler;
 
 	reply_sz = idpf_vc_xn_exec(vport->adapter, xn_params);
 	if (reply_sz < 0)
@@ -3561,11 +3565,20 @@ int idpf_send_create_adi_msg(struct idpf_adapter *adapter,
 {
 	struct idpf_vc_xn_params xn_params = { };
 	ssize_t reply_sz;
+	size_t iov_len;
+	u16 cnt;
 
 	xn_params.vc_op = VIRTCHNL2_OP_NON_FLEX_CREATE_ADI;
 	xn_params.timeout_ms = IDPF_VC_XN_DEFAULT_TIMEOUT_MSEC;
 	xn_params.send_buf.iov_base = vchnl_adi;
-	xn_params.send_buf.iov_len = sizeof(*vchnl_adi);
+	iov_len = sizeof(*vchnl_adi);
+	cnt = le16_to_cpu(vchnl_adi->chunks.num_chunks);
+	if (cnt)
+		iov_len += (cnt - 1) * sizeof(vchnl_adi->chunks.chunks[0]);
+	cnt = le16_to_cpu(vchnl_adi->vchunks.num_vchunks);
+	if (cnt)
+		iov_len += (cnt - 1) * sizeof(vchnl_adi->vchunks.vchunks[0]);
+	xn_params.send_buf.iov_len = iov_len;
 	xn_params.recv_buf.iov_base = vchnl_adi;
 	xn_params.recv_buf.iov_len = IDPF_CTLQ_MAX_BUF_LEN;
 	reply_sz = idpf_vc_xn_exec(adapter, xn_params);
@@ -3850,6 +3863,12 @@ restart:
 
 	idpf_send_get_edt_caps(adapter);
 
+	if (idpf_is_cap_ena(adapter, IDPF_OTHER_CAPS, VIRTCHNL2_CAP_OEM)) {
+		err = idpf_get_oem_caps(adapter);
+		if (err)
+			dev_err(idpf_adapter_to_dev(adapter), "Failed to receive OEM capabilities\n");
+	}
+
 	err = idpf_intr_req(adapter);
 	if (err) {
 		dev_err(idpf_adapter_to_dev(adapter), "failed to enable interrupt vectors: %d\n",
@@ -3860,12 +3879,6 @@ restart:
 	err = idpf_ptp_init(adapter);
 	if (err)
 		dev_err(idpf_adapter_to_dev(adapter), "failed to initialize PTP\n");
-
-	if (idpf_is_cap_ena(adapter, IDPF_OTHER_CAPS, VIRTCHNL2_CAP_OEM)) {
-		err = idpf_get_oem_caps(adapter);
-		if (err)
-			dev_err(idpf_adapter_to_dev(adapter), "Failed to receive OEM capabilities\n");
-	}
 
 	idpf_init_avail_queues(adapter);
 #if IS_ENABLED(CONFIG_VFIO_MDEV) && defined(HAVE_PASID_SUPPORT)
@@ -3881,7 +3894,6 @@ restart:
 	return 0;
 
 err_intr_req:
-	cancel_delayed_work_sync(&adapter->serv_task);
 	idpf_vport_params_buf_rel(adapter);
 err_netdev_alloc:
 	/* We're intentionally not freeing netdevs here because we want them
@@ -3911,7 +3923,6 @@ init_failed:
 	 * the mailbox again
 	 */
 	adapter->state = __IDPF_VER_CHECK;
-	idpf_deinit_dflt_mbx(adapter);
 	set_bit(IDPF_HR_DRV_LOAD, adapter->flags);
 	queue_delayed_work(adapter->vc_event_wq, &adapter->vc_event_task,
 			   msecs_to_jiffies(task_delay));


### PR DESCRIPTION
The following changes were made in this release:
========================================================
- adjust ADI send buffer length
- update pci.ids branding strings
- robustify queue alloc and release paths
- register new lockdep key for PF's init_ctrl locks
- use separate key for PF's VC work items
- add direct method for Tx stamping
- use kernel_ethtool_ts_info for newer kernels