### PR TITLE
idpf: update the copyright year

### DIFF
--- a/auxiliary/src/Makefile
+++ b/auxiliary/src/Makefile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-only
-# Copyright (C) 2019-2025 Intel Corporation
+# Copyright (C) 2019-2026 Intel Corporation
 
 
 ifneq ($(KERNELRELEASE),)

--- a/auxiliary/src/_auxiliary.c
+++ b/auxiliary/src/_auxiliary.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #define pr_fmt(fmt) "%s:%s: " fmt, KBUILD_MODNAME, __func__
 

--- a/auxiliary/src/auxiliary_bus.h
+++ b/auxiliary/src/auxiliary_bus.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _AUXILIARY_BUS_H_
 #define _AUXILIARY_BUS_H_

--- a/auxiliary/src/auxiliary_compat.h
+++ b/auxiliary/src/auxiliary_compat.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _AUXILIARY_COMPAT_H_
 #define _AUXILIARY_COMPAT_H_

--- a/auxiliary/src/common.mk
+++ b/auxiliary/src/common.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-only
-# Copyright (C) 2019-2025 Intel Corporation
+# Copyright (C) 2019-2026 Intel Corporation
 
 #
 # common Makefile rules useful for out-of-tree Linux driver builds

--- a/auxiliary/src/kcompat-generator.sh
+++ b/auxiliary/src/kcompat-generator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-2.0-only
-# Copyright (C) 2019-2025 Intel Corporation
+# Copyright (C) 2019-2026 Intel Corporation
 
 set -Eeuo pipefail
 

--- a/auxiliary/src/kcompat-lib.sh
+++ b/auxiliary/src/kcompat-lib.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-2.0-only
-# Copyright (C) 2019-2025 Intel Corporation
+# Copyright (C) 2019-2026 Intel Corporation
 
 # to be sourced
 

--- a/auxiliary/src/kcompat.c
+++ b/auxiliary/src/kcompat.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "kcompat.h"
 

--- a/auxiliary/src/kcompat.h
+++ b/auxiliary/src/kcompat.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _KCOMPAT_H_
 #define _KCOMPAT_H_

--- a/auxiliary/src/kcompat_cleanup.h
+++ b/auxiliary/src/kcompat_cleanup.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 /* SPDX-License-Identifier: GPL-2.0 */
 #ifndef _KCOMPAT_CLEANUP_H_

--- a/auxiliary/src/kcompat_defs.h
+++ b/auxiliary/src/kcompat_defs.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _KCOMPAT_DEFS_H_
 #define _KCOMPAT_DEFS_H_

--- a/auxiliary/src/kcompat_dim.c
+++ b/auxiliary/src/kcompat_dim.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 // SPDX-License-Identifier: GPL-2.0 OR Linux-OpenIB
 /*

--- a/auxiliary/src/kcompat_dim.h
+++ b/auxiliary/src/kcompat_dim.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 /* SPDX-License-Identifier: GPL-2.0 OR Linux-OpenIB */
 /* Copyright (c) 2019 Mellanox Technologies. */

--- a/auxiliary/src/kcompat_gcc.h
+++ b/auxiliary/src/kcompat_gcc.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _KCOMPAT_GCC_H_
 #define _KCOMPAT_GCC_H_

--- a/auxiliary/src/kcompat_impl.h
+++ b/auxiliary/src/kcompat_impl.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _KCOMPAT_IMPL_H_
 #define _KCOMPAT_IMPL_H_

--- a/auxiliary/src/kcompat_net_dim.c
+++ b/auxiliary/src/kcompat_net_dim.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 // SPDX-License-Identifier: GPL-2.0 OR Linux-OpenIB
 /*

--- a/auxiliary/src/kcompat_overflow.h
+++ b/auxiliary/src/kcompat_overflow.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 /* SPDX-License-Identifier: GPL-2.0 OR MIT */
 #ifndef __LINUX_OVERFLOW_H

--- a/auxiliary/src/kcompat_packing.c
+++ b/auxiliary/src/kcompat_packing.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 // SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
 /* Copyright 2016-2018 NXP

--- a/auxiliary/src/kcompat_packing.h
+++ b/auxiliary/src/kcompat_packing.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright 2016-2018 NXP

--- a/auxiliary/src/kcompat_rhel_defs.h
+++ b/auxiliary/src/kcompat_rhel_defs.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _KCOMPAT_RHEL_DEFS_H_
 #define _KCOMPAT_RHEL_DEFS_H_

--- a/auxiliary/src/kcompat_sles_defs.h
+++ b/auxiliary/src/kcompat_sles_defs.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _KCOMPAT_SLES_DEFS_H_
 #define _KCOMPAT_SLES_DEFS_H_

--- a/auxiliary/src/kcompat_std_defs.h
+++ b/auxiliary/src/kcompat_std_defs.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _KCOMPAT_STD_DEFS_H_
 #define _KCOMPAT_STD_DEFS_H_

--- a/auxiliary/src/kcompat_ubuntu_defs.h
+++ b/auxiliary/src/kcompat_ubuntu_defs.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _KCOMPAT_UBUNTU_DEFS_H_
 #define _KCOMPAT_UBUNTU_DEFS_H_

--- a/auxiliary/src/kcompat_xarray.c
+++ b/auxiliary/src/kcompat_xarray.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 // SPDX-License-Identifier: GPL-2.0+
 /*

--- a/auxiliary/src/kcompat_xarray.h
+++ b/auxiliary/src/kcompat_xarray.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 /* SPDX-License-Identifier: GPL-2.0+ */
 #ifndef _LINUX_XARRAY_H

--- a/idpf/pci.updates
+++ b/idpf/pci.updates
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-only
-# Copyright (C) 2019-2025 Intel Corporation
+# Copyright (C) 2019-2026 Intel Corporation
 
 # updates for the system pci.ids file
 #

--- a/idpf/src/Makefile
+++ b/idpf/src/Makefile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-only
-# Copyright (C) 2019-2025 Intel Corporation
+# Copyright (C) 2019-2026 Intel Corporation
 
 
 ifneq ($(KERNELRELEASE),)

--- a/idpf/src/auxiliary_compat.h
+++ b/idpf/src/auxiliary_compat.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _AUXILIARY_COMPAT_H_
 #define _AUXILIARY_COMPAT_H_

--- a/idpf/src/common.mk
+++ b/idpf/src/common.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-only
-# Copyright (C) 2019-2025 Intel Corporation
+# Copyright (C) 2019-2026 Intel Corporation
 
 #
 # common Makefile rules useful for out-of-tree Linux driver builds

--- a/idpf/src/idc_generic.h
+++ b/idpf/src/idc_generic.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _IDC_GENERIC_H_
 #define _IDC_GENERIC_H_

--- a/idpf/src/idpf.h
+++ b/idpf/src/idpf.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _IDPF_H_
 #define _IDPF_H_

--- a/idpf/src/idpf_adi.c
+++ b/idpf/src/idpf_adi.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "idpf.h"
 #include "idpf_virtchnl.h"

--- a/idpf/src/idpf_adi.h
+++ b/idpf/src/idpf_adi.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _IDPF_ADI_H_
 #define _IDPF_ADI_H_

--- a/idpf/src/idpf_controlq.c
+++ b/idpf/src/idpf_controlq.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "idpf_controlq.h"
 

--- a/idpf/src/idpf_controlq.h
+++ b/idpf/src/idpf_controlq.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _IDPF_CONTROLQ_H_
 #define _IDPF_CONTROLQ_H_

--- a/idpf/src/idpf_controlq_api.h
+++ b/idpf/src/idpf_controlq_api.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _IDPF_CONTROLQ_API_H_
 #define _IDPF_CONTROLQ_API_H_

--- a/idpf/src/idpf_controlq_setup.c
+++ b/idpf/src/idpf_controlq_setup.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "idpf_controlq.h"
 

--- a/idpf/src/idpf_dev.c
+++ b/idpf/src/idpf_dev.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "idpf.h"
 #include "idpf_lan_pf_regs.h"

--- a/idpf/src/idpf_devids.h
+++ b/idpf/src/idpf_devids.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _IDPF_DEVIDS_H_
 #define _IDPF_DEVIDS_H_

--- a/idpf/src/idpf_devlink.c
+++ b/idpf/src/idpf_devlink.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "idpf.h"
 #define DEVLINK_DEFER_TIME (4)  /* 4 milliseconds */

--- a/idpf/src/idpf_devlink.h
+++ b/idpf/src/idpf_devlink.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _IDPF_DEVLINK_H_
 #define _IDPF_DEVLINK_H_

--- a/idpf/src/idpf_ethtool.c
+++ b/idpf/src/idpf_ethtool.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "kcompat.h"
 #include <linux/ethtool.h>

--- a/idpf/src/idpf_idc.c
+++ b/idpf/src/idpf_idc.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "idpf.h"
 #include "idpf_virtchnl.h"

--- a/idpf/src/idpf_lan_pf_regs.h
+++ b/idpf/src/idpf_lan_pf_regs.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _IDPF_LAN_PF_REGS_H_
 #define _IDPF_LAN_PF_REGS_H_

--- a/idpf/src/idpf_lan_txrx.h
+++ b/idpf/src/idpf_lan_txrx.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _IDPF_LAN_TXRX_H_
 #define _IDPF_LAN_TXRX_H_

--- a/idpf/src/idpf_lan_vf_regs.h
+++ b/idpf/src/idpf_lan_vf_regs.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _IDPF_LAN_VF_REGS_H_
 #define _IDPF_LAN_VF_REGS_H_

--- a/idpf/src/idpf_lib.c
+++ b/idpf/src/idpf_lib.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "idpf.h"
 #include "idpf_virtchnl.h"

--- a/idpf/src/idpf_main.c
+++ b/idpf/src/idpf_main.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "kcompat.h"
 #include <linux/aer.h>
@@ -16,7 +16,7 @@
 
 MODULE_VERSION(IDPF_DRV_VER);
 static const char idpf_driver_string[] = DRV_SUMMARY;
-static const char idpf_copyright[] = "Copyright (C) 2019-2025 Intel Corporation";
+static const char idpf_copyright[] = "Copyright (C) 2019-2026 Intel Corporation";
 MODULE_DESCRIPTION(DRV_SUMMARY);
 MODULE_LICENSE("GPL");
 

--- a/idpf/src/idpf_mem.h
+++ b/idpf/src/idpf_mem.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _IDPF_MEM_H_
 #define _IDPF_MEM_H_

--- a/idpf/src/idpf_ptp.c
+++ b/idpf/src/idpf_ptp.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "idpf.h"
 #include "idpf_ptp.h"

--- a/idpf/src/idpf_ptp.h
+++ b/idpf/src/idpf_ptp.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _IDPF_PTP_H_
 #define _IDPF_PTP_H_

--- a/idpf/src/idpf_singleq_txrx.c
+++ b/idpf/src/idpf_singleq_txrx.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "kcompat.h"
 #include <linux/prefetch.h>

--- a/idpf/src/idpf_txrx.c
+++ b/idpf/src/idpf_txrx.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "kcompat.h"
 #include <linux/timer.h>

--- a/idpf/src/idpf_txrx.h
+++ b/idpf/src/idpf_txrx.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _IDPF_TXRX_H_
 #define _IDPF_TXRX_H_

--- a/idpf/src/idpf_vdcm.h
+++ b/idpf/src/idpf_vdcm.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _IDPF_VDCM_H_
 #define _IDPF_VDCM_H_

--- a/idpf/src/idpf_vdcm_dev.c
+++ b/idpf/src/idpf_vdcm_dev.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "idpf.h"
 

--- a/idpf/src/idpf_vdcm_main.c
+++ b/idpf/src/idpf_vdcm_main.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "idpf.h"
 

--- a/idpf/src/idpf_vf_dev.c
+++ b/idpf/src/idpf_vf_dev.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "idpf.h"
 #include "idpf_lan_vf_regs.h"

--- a/idpf/src/idpf_virtchnl.c
+++ b/idpf/src/idpf_virtchnl.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "idpf.h"
 #include "idpf_virtchnl.h"

--- a/idpf/src/idpf_virtchnl.h
+++ b/idpf/src/idpf_virtchnl.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 /* SPDX-License-Identifier: GPL-2.0-only */
 /* Copyright (C) 2024 Intel Corporation */

--- a/idpf/src/idpf_virtchnl_ptp.c
+++ b/idpf/src/idpf_virtchnl_ptp.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "idpf.h"
 #include "idpf_virtchnl.h"

--- a/idpf/src/idpf_xsk.c
+++ b/idpf/src/idpf_xsk.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "idpf.h"
 #ifdef HAVE_NETDEV_BPF_XSK_POOL

--- a/idpf/src/idpf_xsk.h
+++ b/idpf/src/idpf_xsk.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _IDPF_XSK_H_
 #define _IDPF_XSK_H_

--- a/idpf/src/iidc.h
+++ b/idpf/src/iidc.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _IIDC_H_
 #define _IIDC_H_

--- a/idpf/src/iidc_rdma_idpf.h
+++ b/idpf/src/iidc_rdma_idpf.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _IIDC_RDMA_IDPF_H_
 #define _IIDC_RDMA_IDPF_H_

--- a/idpf/src/kcompat-generator.sh
+++ b/idpf/src/kcompat-generator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-2.0-only
-# Copyright (C) 2019-2025 Intel Corporation
+# Copyright (C) 2019-2026 Intel Corporation
 
 set -Eeuo pipefail
 

--- a/idpf/src/kcompat-lib.sh
+++ b/idpf/src/kcompat-lib.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-2.0-only
-# Copyright (C) 2019-2025 Intel Corporation
+# Copyright (C) 2019-2026 Intel Corporation
 
 # to be sourced
 

--- a/idpf/src/kcompat.c
+++ b/idpf/src/kcompat.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #include "kcompat.h"
 

--- a/idpf/src/kcompat.h
+++ b/idpf/src/kcompat.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _KCOMPAT_H_
 #define _KCOMPAT_H_

--- a/idpf/src/kcompat_cleanup.h
+++ b/idpf/src/kcompat_cleanup.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 /* SPDX-License-Identifier: GPL-2.0 */
 #ifndef _KCOMPAT_CLEANUP_H_

--- a/idpf/src/kcompat_defs.h
+++ b/idpf/src/kcompat_defs.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _KCOMPAT_DEFS_H_
 #define _KCOMPAT_DEFS_H_

--- a/idpf/src/kcompat_dim.c
+++ b/idpf/src/kcompat_dim.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 // SPDX-License-Identifier: GPL-2.0 OR Linux-OpenIB
 /*

--- a/idpf/src/kcompat_dim.h
+++ b/idpf/src/kcompat_dim.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 /* SPDX-License-Identifier: GPL-2.0 OR Linux-OpenIB */
 /* Copyright (c) 2019 Mellanox Technologies. */

--- a/idpf/src/kcompat_gcc.h
+++ b/idpf/src/kcompat_gcc.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _KCOMPAT_GCC_H_
 #define _KCOMPAT_GCC_H_

--- a/idpf/src/kcompat_impl.h
+++ b/idpf/src/kcompat_impl.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _KCOMPAT_IMPL_H_
 #define _KCOMPAT_IMPL_H_

--- a/idpf/src/kcompat_net_dim.c
+++ b/idpf/src/kcompat_net_dim.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 // SPDX-License-Identifier: GPL-2.0 OR Linux-OpenIB
 /*

--- a/idpf/src/kcompat_overflow.h
+++ b/idpf/src/kcompat_overflow.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 /* SPDX-License-Identifier: GPL-2.0 OR MIT */
 #ifndef __LINUX_OVERFLOW_H

--- a/idpf/src/kcompat_packing.c
+++ b/idpf/src/kcompat_packing.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 // SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
 /* Copyright 2016-2018 NXP

--- a/idpf/src/kcompat_packing.h
+++ b/idpf/src/kcompat_packing.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright 2016-2018 NXP

--- a/idpf/src/kcompat_rhel_defs.h
+++ b/idpf/src/kcompat_rhel_defs.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _KCOMPAT_RHEL_DEFS_H_
 #define _KCOMPAT_RHEL_DEFS_H_

--- a/idpf/src/kcompat_sles_defs.h
+++ b/idpf/src/kcompat_sles_defs.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _KCOMPAT_SLES_DEFS_H_
 #define _KCOMPAT_SLES_DEFS_H_

--- a/idpf/src/kcompat_std_defs.h
+++ b/idpf/src/kcompat_std_defs.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _KCOMPAT_STD_DEFS_H_
 #define _KCOMPAT_STD_DEFS_H_

--- a/idpf/src/kcompat_ubuntu_defs.h
+++ b/idpf/src/kcompat_ubuntu_defs.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _KCOMPAT_UBUNTU_DEFS_H_
 #define _KCOMPAT_UBUNTU_DEFS_H_

--- a/idpf/src/kcompat_xarray.c
+++ b/idpf/src/kcompat_xarray.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 // SPDX-License-Identifier: GPL-2.0+
 /*

--- a/idpf/src/kcompat_xarray.h
+++ b/idpf/src/kcompat_xarray.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 /* SPDX-License-Identifier: GPL-2.0+ */
 #ifndef _LINUX_XARRAY_H

--- a/idpf/src/libeth_tx.h
+++ b/idpf/src/libeth_tx.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 /* SPDX-License-Identifier: GPL-2.0-only */
 /* Copyright (C) 2024-2025 Intel Corporation */

--- a/idpf/src/libeth_types.h
+++ b/idpf/src/libeth_types.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 /* SPDX-License-Identifier: GPL-2.0-only */
 /* Copyright (C) 2024-2025 Intel Corporation */

--- a/idpf/src/siov_regs.h
+++ b/idpf/src/siov_regs.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 /*
  * Copyright (C) 2023 Intel Corporation

--- a/idpf/src/virtchnl2.h
+++ b/idpf/src/virtchnl2.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _VIRTCHNL2_H_
 #define _VIRTCHNL2_H_

--- a/idpf/src/virtchnl2_lan_desc.h
+++ b/idpf/src/virtchnl2_lan_desc.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _VIRTCHNL2_LAN_DESC_H_
 #define _VIRTCHNL2_LAN_DESC_H_

--- a/linux/auxiliary_bus.h
+++ b/linux/auxiliary_bus.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-/* Copyright (C) 2019-2025 Intel Corporation */
+/* Copyright (C) 2019-2026 Intel Corporation */
 
 #ifndef _AUXILIARY_BUS_H_
 #define _AUXILIARY_BUS_H_


### PR DESCRIPTION
This commit updates the copyright year
of the source files from 2025 to 2026.

Change-type: Other
Signed-off-by: Sarath Somasekharan <sarath.somasekharan@intel.com>