### PR TITLE
ci: idpf patch integration from 17d0d046 to fd9d5ba6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Copyright (C) 2021 Intel Corporation
 
 TARGETS := idpf auxiliary
-VERSION := 1.0.8
+VERSION := 1.0.9
 
 # Shortcut version target
 ifneq ($(filter version,${MAKECMDGOALS}),)

--- a/idpf.spec
+++ b/idpf.spec
@@ -1,6 +1,6 @@
 Name: idpf
 Summary: Infrastructure Data Path Function Linux Driver
-Version: 1.0.8
+Version: 1.0.9
 Release: 1
 Source: %{name}-%{version}.tar.gz
 Vendor: Intel Corporation

--- a/idpf/src/idpf.h
+++ b/idpf/src/idpf.h
@@ -54,7 +54,7 @@ struct idpf_rss_data;
 #endif /* CONFIG_IOMMU_BYPASS */
 
 #define IDPF_DRV_NAME "idpf"
-#define IDPF_DRV_VER "1.0.8"
+#define IDPF_DRV_VER "1.0.9"
 
 #define IDPF_M(m, s)	((m) << (s))
 

--- a/idpf/src/iidc.h
+++ b/idpf/src/iidc.h
@@ -230,14 +230,13 @@ struct iidc_core_dev_info {
 	 * private data accessible only to the specific auxiliary driver.
 	 */
 	void *iidc_priv;
+	struct iidc_ver_info ver;
 
 	/* KVA / Linear address corresponding to BAR0 of underlying
 	 * pci_device.
 	 */
 	u8 __iomem *hw_addr;
 	int cdev_info_id;
-	struct iidc_ver_info ver;
-
 	/* Opaque pointer for aux driver specific data tracking. This memory
 	 * will be alloc'd and freed by the auxiliary driver and used for
 	 * private data accessible only to the specific auxiliary driver.


### PR DESCRIPTION
Automated patch and base file integration by CI pipeline

**Source commits:**
- Start: 17d0d046 (monorepo base)
- End: fd9d5ba6 (source head)

**Configuration:**
- Clean branch: false
- Strip metadata: true

**Source repository:** intel-innersource/drivers.ethernet.linux.mev-dp
**Generated by:** intel-innersource/drivers.ethernet.linux.idpf-gchelper

This PR contains patches automatically generated (non-scratch incremental mode) by the gchelper workflow.
Metadata fields have been stripped from commit messages, preserving Signed-off-by, Change-Type, and Closes fields.

**Target:** Merge to main branch of intel/ethernet-linux-idpf